### PR TITLE
fix: handle passing collection_label so that all features are returned regardless of their feature collection

### DIFF
--- a/rdf2geojson/convert.py
+++ b/rdf2geojson/convert.py
@@ -1004,6 +1004,14 @@ def convert(
         if not conforms:
             print(results_text)
             return {}
+
+    if collection_label is not None:
+        if kind == "human":
+            features = get_converted_features_for_human(g, iri2id=iri2id)
+        else:
+            features = get_converted_features(g, iri2id=iri2id)
+        return FeatureCollection(features, title=collection_label)
+
     if kind == "human":
         feature_collections = get_features_collections_for_human(g, iri2id=iri2id)
     else:


### PR DESCRIPTION
Currently if a set of features is found via CQL and they are from different feature collections, and those feature collections are included in the RDF response, the converter will take the first feature collection it finds and only return the features in this.

This change adds a check for the collection label prior to other processing, and if present returns a feature collection with this label with all features in the graph.

I have tagged this v0.5.1 and updated prez with this dep.